### PR TITLE
update agnostik

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ socket2 = { version = "0.3.12", features = ["pair", "unix"] }
 libc = "0.2"
 pin-utils = "0.1.0"
 once_cell = "1.4.0"
-agnostik = "0.1.4"
+agnostik = "0.2.0"
 
 # Other backends
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
This is the last step for bastion depending on one version of bastion-executor instead of two (currently depends on 0.3 because of nuclei -> agnostik).
A release with this in would be great!